### PR TITLE
Odometry dataset support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # Pycharm
 *.idea
+
+# Temporary files from text editors
+*~

--- a/bin/kitti2bag
+++ b/bin/kitti2bag
@@ -23,6 +23,7 @@ import sensor_msgs.point_cloud2 as pcl2
 from geometry_msgs.msg import TransformStamped, TwistStamped, Transform
 from cv_bridge import CvBridge
 import numpy as np
+import argparse
 
 
 def save_imu_data(bag, kitti, imu_frame_id, topic):
@@ -72,40 +73,69 @@ def save_dynamic_tf(bag, kitti):
         tf_oxts_msg.transforms.append(tf_oxts_transform)
 
         bag.write('/tf', tf_oxts_msg, tf_oxts_msg.transforms[0].header.stamp)
-
-
-def save_camera_data(bag, kitti, util, bridge, camera, camera_frame_id, topic):
+        
+def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_id, topic):
     print("Exporting camera {}".format(camera))
-    camera_pad = '{0:02d}'.format(camera)
-    image_path = os.path.join(kitti.data_path, 'image_{}'.format(camera_pad))
-    img_data_dir = os.path.join(image_path, 'data')
-    img_filenames = sorted(os.listdir(img_data_dir))
-    with open(os.path.join(image_path, 'timestamps.txt')) as f:
-        img_datetimes = map(lambda x: datetime.strptime(x[:-4], '%Y-%m-%d %H:%M:%S.%f'), f.readlines())
+    
+    
+    if kitti_type.find("raw") != -1:
+        camera_pad = '{0:02d}'.format(camera)
+        image_dir = os.path.join(kitti.data_path, 'image_{}'.format(camera_pad))
+        image_path = os.path.join(image_path, 'data')
+        image_filenames = sorted(os.listdir(image_path))
+        with open(os.path.join(image_dir, 'timestamps.txt')) as f:
+            img_datetimes = map(lambda x: datetime.strptime(x[:-4], '%Y-%m-%d %H:%M:%S.%f'), f.readlines())
+        
+        calib = CameraInfo()
+        calib.header.frame_id = camera_frame_id
+        calib.width, calib.height = tuple(util['S_rect_{}'.format(camera_pad)].tolist())
+        calib.distortion_model = 'plumb_bob'
+        calib.K = util['K_{}'.format(camera_pad)]
+        calib.R = util['R_rect_{}'.format(camera_pad)]
+        calib.D = util['D_{}'.format(camera_pad)]
+        calib.P = util['P_rect_{}'.format(camera_pad)]
 
-    calib = CameraInfo()
-    calib.header.frame_id = camera_frame_id
-    calib.width, calib.height = tuple(util['S_rect_{}'.format(camera_pad)].tolist())
-    calib.distortion_model = 'plumb_bob'
-    calib.K = util['K_{}'.format(camera_pad)]
-    calib.R = util['R_rect_{}'.format(camera_pad)]
-    calib.D = util['D_{}'.format(camera_pad)]
-    calib.P = util['P_rect_{}'.format(camera_pad)]
+        iterable = zip(img_datetimes, image_filenames)
+        bar = progressbar.ProgressBar()
+        for dt, filename in bar(iterable):
+            img_filename = os.path.join(image_path, filename)
+            cv_image = cv2.imread(img_filename)
+            if camera in (0, 1):
+                cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
+            encoding = "mono8" if camera in (0, 1) else "bgr8"
+            image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
+            image_message.header.frame_id = camera_frame_id
+            image_message.header.stamp = rospy.Time.from_sec(float(datetime.strftime(dt, "%s.%f")))
+            calib.header.stamp = image_message.header.stamp
+            bag.write(topic + '/image_raw', image_message, t=image_message.header.stamp)
+            bag.write(topic + '/camera_info', calib, t=calib.header.stamp)
+            
+    elif kitti_type.find("odom") != -1:
+        camera_pad = '{0:01d}'.format(camera)
+        image_path = os.path.join(kitti.sequence_path, 'image_{}'.format(camera_pad))
+        image_filenames = sorted(os.listdir(image_path))
+        current_epoch = (datetime.utcnow() - datetime(1970, 1, 1)).total_seconds()
+        with open(os.path.join(kitti.sequence_path, 'times.txt')) as f:
+            img_datetimes = map(lambda x: current_epoch + float(x), f.readlines())
+        
+        calib = CameraInfo()
 
-    iterable = zip(img_datetimes, img_filenames)
-    bar = progressbar.ProgressBar()
-    for dt, filename in bar(iterable):
-        img_filename = os.path.join(img_data_dir, filename)
-        cv_image = cv2.imread(img_filename)
-        if camera in (0, 1):
-            cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
-        encoding = "mono8" if camera in (0, 1) else "bgr8"
-        image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
-        image_message.header.frame_id = camera_frame_id
-        image_message.header.stamp = rospy.Time.from_sec(float(datetime.strftime(dt, "%s.%f")))
-        calib.header.stamp = image_message.header.stamp
-        bag.write(topic + '/image_raw', image_message, t=image_message.header.stamp)
-        bag.write(topic + '/camera_info', calib, t=calib.header.stamp)
+        iterable = zip(img_datetimes, image_filenames)
+        bar = progressbar.ProgressBar()
+        for dt, filename in bar(iterable):
+            img_filename = os.path.join(image_path, filename)
+            cv_image = cv2.imread(img_filename)
+            if camera in (0, 1):
+                cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
+            encoding = "mono8" if camera in (0, 1) else "bgr8"
+            image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
+            image_message.header.frame_id = camera_frame_id
+            image_message.header.stamp = rospy.Time.from_sec(dt)
+            calib.header.stamp = image_message.header.stamp
+            bag.write(topic + '/image_raw', image_message, t=image_message.header.stamp)
+            bag.write(topic + '/camera_info', calib, t=calib.header.stamp)
+
+    
 
 
 def save_velo_data(bag, kitti, velo_frame_id, topic):
@@ -215,79 +245,141 @@ def save_gps_vel_data(bag, kitti, gps_frame_id, topic):
 
 
 def main():
-    if len(sys.argv) not in (3, 4):
-        print("Usage: kitti2bag base_dir date drive")
-        print("   or: kitti2bag date drive (base_dir is then current dir)")
-        return
-    basedir = sys.argv[1] if len(sys.argv) == 4 else os.getcwd()
-    date, drive = tuple(sys.argv[-2:])
+    
+    parser = argparse.ArgumentParser(description = "Convert KITTI dataset to ROS bag file the easy way!")
+    # Accepted argument values
+    kitti_types = ["raw_synced", "odom_color", "odom_gray"]
+    odometry_sequences = []
+    for s in range(22):
+        odometry_sequences.append(str(s).zfill(2))
+    
+    parser.add_argument("kitti_type", choices = kitti_types, help = "KITTI dataset type")
+    parser.add_argument("dir", nargs = "?", default = os.getcwd(), help = "base directory of the dataset, if no directory passed the deafult is current working directory")
+    parser.add_argument("-t", "--date", help = "date of the raw dataset (i.e. 2011_09_26), option is only for RAW datasets.")
+    parser.add_argument("-r", "--drive", help = "drive number of the raw dataset (i.e. 0001), option is only for RAW datasets.")
+    parser.add_argument("-s", "--sequence", choices = odometry_sequences,help = "sequence of the odometry dataset (between 00 - 21), option is only for ODOMETRY datasets.")
+    args = parser.parse_args()
 
     bridge = CvBridge()
     compression = rosbag.Compression.NONE
     # compression = rosbag.Compression.BZ2
     # compression = rosbag.Compression.LZ4
-    bag = rosbag.Bag("kitti_{}_drive_{}_sync.bag".format(date, drive), 'w', compression=compression)
-    kitti = pykitti.raw(basedir, date, drive)
-    if not os.path.exists(kitti.data_path):
-        print('Path {} does not exists. Exiting.'.format(kitti.data_path))
-        sys.exit(1)
 
-    kitti.load_calib()
-    kitti.load_oxts()
-    kitti.load_timestamps()
-    # kitti.load_velo()
+    if args.kitti_type == "raw_synced":
+    
+        if args.date == None:
+            print("Date option is not given. It is mandatory for raw dataset.")
+            print("Usage for raw dataset: kitti2bag raw_synced [dir] -t <date> -r <drive>")
+            sys.exit(1)
+        elif args.drive == None:
+            print("Drive option is not given. It is mandatory for raw dataset.")
+            print("Usage for raw dataset: kitti2bag raw_synced [dir] -t <date> -r <drive>")
+            sys.exit(1)
+        
+        bag = rosbag.Bag("kitti_{}_drive_{}_sync.bag".format(args.date, args.drive), 'w', compression=compression)
+        kitti = pykitti.raw(args.dir, args.date, args.drive)
+        if not os.path.exists(kitti.data_path):
+            print('Path {} does not exists. Exiting.'.format(kitti.data_path))
+            sys.exit(1)
 
-    if len(kitti.timestamps) == 0:
-        print('Dataset is empty? Exiting.')
-        sys.exit(1)
+        kitti.load_calib()
+        kitti.load_oxts()
+        kitti.load_timestamps()
+        # kitti.load_velo()
 
-    try:
-        # IMU
-        imu_frame_id = 'imu_link'
-        imu_topic = '/kitti/oxts/imu'
-        gps_fix_topic = '/kitti/oxts/gps/fix'
-        gps_vel_topic = '/kitti/oxts/gps/vel'
-        velo_frame_id = 'velo_link'
-        velo_topic = '/kitti/velo'
+        if len(kitti.timestamps) == 0:
+            print('Dataset is empty? Exiting.')
+            sys.exit(1)
 
-        # CAMERAS
-        cameras = [
-            (0, 'camera_gray_left', '/kitti/camera_gray_left'),
-            (1, 'camera_gray_right', '/kitti/camera_gray_right'),
-            (2, 'camera_color_left', '/kitti/camera_color_left'),
-            (3, 'camera_color_right', '/kitti/camera_color_right')
-        ]
+        try:
+            # IMU
+            imu_frame_id = 'imu_link'
+            imu_topic = '/kitti/oxts/imu'
+            gps_fix_topic = '/kitti/oxts/gps/fix'
+            gps_vel_topic = '/kitti/oxts/gps/vel'
+            velo_frame_id = 'velo_link'
+            velo_topic = '/kitti/velo'
 
-        T_base_link_to_imu = np.eye(4, 4)
-        T_base_link_to_imu[0:3, 3] = [-2.71/2.0-0.05, 0.32, 0.93]
+            # CAMERAS
+            cameras = [
+                (0, 'camera_gray_left', '/kitti/camera_gray_left'),
+                (1, 'camera_gray_right', '/kitti/camera_gray_right'),
+                (2, 'camera_color_left', '/kitti/camera_color_left'),
+                (3, 'camera_color_right', '/kitti/camera_color_right')
+            ]
 
-        # tf_static
-        transforms = [
-            ('base_link', imu_frame_id, T_base_link_to_imu),
-            (imu_frame_id, velo_frame_id, inv(kitti.calib.T_velo_imu)),
-            (imu_frame_id, cameras[0][1], inv(kitti.calib.T_cam0_imu)),
-            (imu_frame_id, cameras[1][1], inv(kitti.calib.T_cam1_imu)),
-            (imu_frame_id, cameras[2][1], inv(kitti.calib.T_cam2_imu)),
-            (imu_frame_id, cameras[3][1], inv(kitti.calib.T_cam3_imu))
-        ]
+            T_base_link_to_imu = np.eye(4, 4)
+            T_base_link_to_imu[0:3, 3] = [-2.71/2.0-0.05, 0.32, 0.93]
 
-        util = pykitti.utils.read_calib_file(os.path.join(kitti.calib_path, 'calib_cam_to_cam.txt'))
+            # tf_static
+            transforms = [
+                ('base_link', imu_frame_id, T_base_link_to_imu),
+                (imu_frame_id, velo_frame_id, inv(kitti.calib.T_velo_imu)),
+                (imu_frame_id, cameras[0][1], inv(kitti.calib.T_cam0_imu)),
+                (imu_frame_id, cameras[1][1], inv(kitti.calib.T_cam1_imu)),
+                (imu_frame_id, cameras[2][1], inv(kitti.calib.T_cam2_imu)),
+                (imu_frame_id, cameras[3][1], inv(kitti.calib.T_cam3_imu))
+            ]
 
-        # Export
-        save_static_transforms(bag, transforms, kitti.timestamps)
-        save_dynamic_tf(bag, kitti)
-        save_imu_data(bag, kitti, imu_frame_id, imu_topic)
-        save_gps_fix_data(bag, kitti, imu_frame_id, gps_fix_topic)
-        save_gps_vel_data(bag, kitti, imu_frame_id, gps_vel_topic)
-        for camera in cameras:
-            save_camera_data(bag, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2])
-        save_velo_data(bag, kitti, velo_frame_id, velo_topic)
+            util = pykitti.utils.read_calib_file(os.path.join(kitti.calib_path, 'calib_cam_to_cam.txt'))
+
+            # Export
+            save_static_transforms(bag, transforms, kitti.timestamps)
+            save_dynamic_tf(bag, kitti)
+            save_imu_data(bag, kitti, imu_frame_id, imu_topic)
+            save_gps_fix_data(bag, kitti, imu_frame_id, gps_fix_topic)
+            save_gps_vel_data(bag, kitti, imu_frame_id, gps_vel_topic)
+            for camera in cameras:
+                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2])
+            save_velo_data(bag, kitti, velo_frame_id, velo_topic)
 
 
-    finally:
-        print("## OVERVIEW ##")
-        print(bag)
-        bag.close()
+        finally:
+            print("## OVERVIEW ##")
+            print(bag)
+            bag.close()
+            
+    elif args.kitti_type == "odom_color":
+        
+        if args.sequence == None:
+            print("Sequence option is not given. It is mandatory for odometry dataset.")
+            print("Usage for odometry dataset: kitti2bag {odom_color, odom_gray} [dir] -s <sequence>")
+            sys.exit(1)
+            
+        bag = rosbag.Bag("kitti_data_odometry_color.bag", 'w', compression=compression)
+            
+        kitti = pykitti.odometry(args.dir, args.sequence, range(0,1000,5))
+        if not os.path.exists(kitti.sequence_path):
+            print('Path {} does not exists. Exiting.'.format(kitti.data_path))
+            sys.exit(1)
+
+        kitti.load_calib()        
+        kitti.load_timestamps()   
+        #kitti.load_poses()        
+        kitti.load_rgb()          
+
+        if len(kitti.timestamps) == 0:
+            print('Dataset is empty? Exiting.')
+            sys.exit(1)
+
+        try:
+            # CAMERAS
+            cameras = [
+                (2, 'camera_color_left', '/kitti/camera_color_left'),
+                (3, 'camera_color_right', '/kitti/camera_color_right')
+            ]
+
+            util = pykitti.utils.read_calib_file(os.path.join(args.dir,'sequences',args.sequence, 'calib.txt'))
+
+            # Export
+            for camera in cameras:
+                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2])
+
+        finally:
+            print("## OVERVIEW ##")
+            print(bag)
+            bag.close()
+        
 
 
 if __name__ == '__main__':

--- a/bin/kitti2bag
+++ b/bin/kitti2bag
@@ -44,7 +44,6 @@ def save_imu_data(bag, kitti, imu_frame_id, topic):
         imu.angular_velocity.z = oxts.packet.wu
         bag.write(topic, imu, t=imu.header.stamp)
 
-
 def save_dynamic_tf(bag, kitti):
     print("Exporting time dependent transformations")
     for timestamp, oxts in zip(kitti.timestamps, kitti.oxts):
@@ -72,6 +71,7 @@ def save_dynamic_tf(bag, kitti):
         tf_oxts_msg.transforms.append(tf_oxts_transform)
 
         bag.write('/tf', tf_oxts_msg, tf_oxts_msg.transforms[0].header.stamp)
+
         
 def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_id, topic, initial_time):
     print("Exporting camera {}".format(camera))
@@ -96,8 +96,7 @@ def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_
         camera_pad = '{0:01d}'.format(camera)
         image_path = os.path.join(kitti.sequence_path, 'image_{}'.format(camera_pad))
         image_filenames = sorted(os.listdir(image_path))
-        with open(os.path.join(kitti.sequence_path, 'times.txt')) as f:
-            image_datetimes = map(lambda x: initial_time + float(x), f.readlines())
+        image_datetimes = map(lambda x: initial_time + x.total_seconds(), kitti.timestamps)
         
         calib = CameraInfo()
         calib.header.frame_id = camera_frame_id
@@ -340,9 +339,8 @@ def main():
             sys.exit(1)
 
         kitti.load_calib()        
-        kitti.load_timestamps()   
-        #kitti.load_poses()        
-
+        kitti.load_timestamps()  
+        #kitti.load_poses()     
         if len(kitti.timestamps) == 0:
             print('Dataset is empty? Exiting.')
             sys.exit(1)

--- a/bin/kitti2bag
+++ b/bin/kitti2bag
@@ -25,7 +25,6 @@ from cv_bridge import CvBridge
 import numpy as np
 import argparse
 
-
 def save_imu_data(bag, kitti, imu_frame_id, topic):
     print("Exporting IMU")
     for timestamp, oxts in zip(kitti.timestamps, kitti.oxts):
@@ -74,17 +73,15 @@ def save_dynamic_tf(bag, kitti):
 
         bag.write('/tf', tf_oxts_msg, tf_oxts_msg.transforms[0].header.stamp)
         
-def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_id, topic):
+def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_id, topic, initial_time):
     print("Exporting camera {}".format(camera))
-    
-    
     if kitti_type.find("raw") != -1:
         camera_pad = '{0:02d}'.format(camera)
         image_dir = os.path.join(kitti.data_path, 'image_{}'.format(camera_pad))
-        image_path = os.path.join(image_path, 'data')
+        image_path = os.path.join(image_dir, 'data')
         image_filenames = sorted(os.listdir(image_path))
         with open(os.path.join(image_dir, 'timestamps.txt')) as f:
-            img_datetimes = map(lambda x: datetime.strptime(x[:-4], '%Y-%m-%d %H:%M:%S.%f'), f.readlines())
+            image_datetimes = map(lambda x: datetime.strptime(x[:-4], '%Y-%m-%d %H:%M:%S.%f'), f.readlines())
         
         calib = CameraInfo()
         calib.header.frame_id = camera_frame_id
@@ -94,50 +91,39 @@ def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_
         calib.R = util['R_rect_{}'.format(camera_pad)]
         calib.D = util['D_{}'.format(camera_pad)]
         calib.P = util['P_rect_{}'.format(camera_pad)]
-
-        iterable = zip(img_datetimes, image_filenames)
-        bar = progressbar.ProgressBar()
-        for dt, filename in bar(iterable):
-            img_filename = os.path.join(image_path, filename)
-            cv_image = cv2.imread(img_filename)
-            if camera in (0, 1):
-                cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
-            encoding = "mono8" if camera in (0, 1) else "bgr8"
-            image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
-            image_message.header.frame_id = camera_frame_id
-            image_message.header.stamp = rospy.Time.from_sec(float(datetime.strftime(dt, "%s.%f")))
-            calib.header.stamp = image_message.header.stamp
-            bag.write(topic + '/image_raw', image_message, t=image_message.header.stamp)
-            bag.write(topic + '/camera_info', calib, t=calib.header.stamp)
             
     elif kitti_type.find("odom") != -1:
         camera_pad = '{0:01d}'.format(camera)
         image_path = os.path.join(kitti.sequence_path, 'image_{}'.format(camera_pad))
         image_filenames = sorted(os.listdir(image_path))
-        current_epoch = (datetime.utcnow() - datetime(1970, 1, 1)).total_seconds()
         with open(os.path.join(kitti.sequence_path, 'times.txt')) as f:
-            img_datetimes = map(lambda x: current_epoch + float(x), f.readlines())
+            image_datetimes = map(lambda x: initial_time + float(x), f.readlines())
         
         calib = CameraInfo()
-
-        iterable = zip(img_datetimes, image_filenames)
-        bar = progressbar.ProgressBar()
-        for dt, filename in bar(iterable):
-            img_filename = os.path.join(image_path, filename)
-            cv_image = cv2.imread(img_filename)
-            if camera in (0, 1):
-                cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
-            encoding = "mono8" if camera in (0, 1) else "bgr8"
-            image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
-            image_message.header.frame_id = camera_frame_id
-            image_message.header.stamp = rospy.Time.from_sec(dt)
-            calib.header.stamp = image_message.header.stamp
-            bag.write(topic + '/image_raw', image_message, t=image_message.header.stamp)
-            bag.write(topic + '/camera_info', calib, t=calib.header.stamp)
-
+        calib.header.frame_id = camera_frame_id
+        calib.P = util['P{}'.format(camera_pad)]
     
-
-
+    iterable = zip(image_datetimes, image_filenames)
+    bar = progressbar.ProgressBar()
+    for dt, filename in bar(iterable):
+        image_filename = os.path.join(image_path, filename)
+        cv_image = cv2.imread(image_filename)
+        calib.width, calib.height = cv_image.shape[:2]
+        if camera in (0, 1):
+            cv_image = cv2.cvtColor(cv_image, cv2.COLOR_BGR2GRAY)
+        encoding = "mono8" if camera in (0, 1) else "bgr8"
+        image_message = bridge.cv2_to_imgmsg(cv_image, encoding=encoding)
+        image_message.header.frame_id = camera_frame_id
+        if kitti_type.find("raw") != -1:
+            image_message.header.stamp = rospy.Time.from_sec(float(datetime.strftime(dt, "%s.%f")))
+            topic_ext = "/image_raw"
+        elif kitti_type.find("odom") != -1:
+            image_message.header.stamp = rospy.Time.from_sec(dt)
+            topic_ext = "/image_rect"
+        calib.header.stamp = image_message.header.stamp
+        bag.write(topic + topic_ext, image_message, t = image_message.header.stamp)
+        bag.write(topic + '/camera_info', calib, t = calib.header.stamp) 
+        
 def save_velo_data(bag, kitti, velo_frame_id, topic):
     print("Exporting velodyne data")
     velo_path = os.path.join(kitti.data_path, 'velodyne_points')
@@ -264,8 +250,16 @@ def main():
     compression = rosbag.Compression.NONE
     # compression = rosbag.Compression.BZ2
     # compression = rosbag.Compression.LZ4
+    
+    # CAMERAS
+    cameras = [
+        (0, 'camera_gray_left', '/kitti/camera_gray_left'),
+        (1, 'camera_gray_right', '/kitti/camera_gray_right'),
+        (2, 'camera_color_left', '/kitti/camera_color_left'),
+        (3, 'camera_color_right', '/kitti/camera_color_right')
+    ]
 
-    if args.kitti_type == "raw_synced":
+    if args.kitti_type.find("raw") != -1:
     
         if args.date == None:
             print("Date option is not given. It is mandatory for raw dataset.")
@@ -276,7 +270,7 @@ def main():
             print("Usage for raw dataset: kitti2bag raw_synced [dir] -t <date> -r <drive>")
             sys.exit(1)
         
-        bag = rosbag.Bag("kitti_{}_drive_{}_sync.bag".format(args.date, args.drive), 'w', compression=compression)
+        bag = rosbag.Bag("kitti_{}_drive_{}_{}.bag".format(args.date, args.drive, args.kitti_type[4:]), 'w', compression=compression)
         kitti = pykitti.raw(args.dir, args.date, args.drive)
         if not os.path.exists(kitti.data_path):
             print('Path {} does not exists. Exiting.'.format(kitti.data_path))
@@ -300,14 +294,6 @@ def main():
             velo_frame_id = 'velo_link'
             velo_topic = '/kitti/velo'
 
-            # CAMERAS
-            cameras = [
-                (0, 'camera_gray_left', '/kitti/camera_gray_left'),
-                (1, 'camera_gray_right', '/kitti/camera_gray_right'),
-                (2, 'camera_color_left', '/kitti/camera_color_left'),
-                (3, 'camera_color_right', '/kitti/camera_color_right')
-            ]
-
             T_base_link_to_imu = np.eye(4, 4)
             T_base_link_to_imu[0:3, 3] = [-2.71/2.0-0.05, 0.32, 0.93]
 
@@ -330,7 +316,7 @@ def main():
             save_gps_fix_data(bag, kitti, imu_frame_id, gps_fix_topic)
             save_gps_vel_data(bag, kitti, imu_frame_id, gps_vel_topic)
             for camera in cameras:
-                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2])
+                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2], initial_time=None)
             save_velo_data(bag, kitti, velo_frame_id, velo_topic)
 
 
@@ -339,48 +325,44 @@ def main():
             print(bag)
             bag.close()
             
-    elif args.kitti_type == "odom_color":
+    elif args.kitti_type.find("odom") != -1:
         
         if args.sequence == None:
             print("Sequence option is not given. It is mandatory for odometry dataset.")
             print("Usage for odometry dataset: kitti2bag {odom_color, odom_gray} [dir] -s <sequence>")
             sys.exit(1)
             
-        bag = rosbag.Bag("kitti_data_odometry_color.bag", 'w', compression=compression)
-            
-        kitti = pykitti.odometry(args.dir, args.sequence, range(0,1000,5))
+        bag = rosbag.Bag("kitti_data_odometry_{}.bag".format(args.kitti_type[5:]), 'w', compression=compression)
+        
+        kitti = pykitti.odometry(args.dir, args.sequence)
         if not os.path.exists(kitti.sequence_path):
-            print('Path {} does not exists. Exiting.'.format(kitti.data_path))
+            print('Path {} does not exists. Exiting.'.format(kitti.sequence_path))
             sys.exit(1)
 
         kitti.load_calib()        
         kitti.load_timestamps()   
         #kitti.load_poses()        
-        kitti.load_rgb()          
 
         if len(kitti.timestamps) == 0:
             print('Dataset is empty? Exiting.')
             sys.exit(1)
 
         try:
-            # CAMERAS
-            cameras = [
-                (2, 'camera_color_left', '/kitti/camera_color_left'),
-                (3, 'camera_color_right', '/kitti/camera_color_right')
-            ]
-
             util = pykitti.utils.read_calib_file(os.path.join(args.dir,'sequences',args.sequence, 'calib.txt'))
-
+            current_epoch = (datetime.utcnow() - datetime(1970, 1, 1)).total_seconds()
             # Export
-            for camera in cameras:
-                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2])
+            if args.kitti_type.find("gray") != -1:
+                used_cameras = cameras[:2]
+            elif args.kitti_type.find("color") != -1:
+                used_cameras = cameras[-2:]
+
+            for camera in used_cameras:
+                save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2], initial_time=current_epoch)
 
         finally:
             print("## OVERVIEW ##")
             print(bag)
             bag.close()
-        
-
 
 if __name__ == '__main__':
     main()

--- a/bin/kitti2bag
+++ b/bin/kitti2bag
@@ -44,34 +44,63 @@ def save_imu_data(bag, kitti, imu_frame_id, topic):
         imu.angular_velocity.z = oxts.packet.wu
         bag.write(topic, imu, t=imu.header.stamp)
 
-def save_dynamic_tf(bag, kitti):
+
+def save_dynamic_tf(bag, kitti, kitti_type, initial_time):
     print("Exporting time dependent transformations")
-    for timestamp, oxts in zip(kitti.timestamps, kitti.oxts):
-        tf_oxts_msg = TFMessage()
-        tf_oxts_transform = TransformStamped()
-        tf_oxts_transform.header.stamp = rospy.Time.from_sec(float(timestamp.strftime("%s.%f")))
-        tf_oxts_transform.header.frame_id = 'world'
-        tf_oxts_transform.child_frame_id = 'base_link'
+    if kitti_type.find("raw") != -1:
+        for timestamp, oxts in zip(kitti.timestamps, kitti.oxts):
+            tf_oxts_msg = TFMessage()
+            tf_oxts_transform = TransformStamped()
+            tf_oxts_transform.header.stamp = rospy.Time.from_sec(float(timestamp.strftime("%s.%f")))
+            tf_oxts_transform.header.frame_id = 'world'
+            tf_oxts_transform.child_frame_id = 'base_link'
 
-        transform = (oxts.T_w_imu)
-        t = transform[0:3, 3]
-        q = tf.transformations.quaternion_from_matrix(transform)
-        oxts_tf = Transform()
+            transform = (oxts.T_w_imu)
+            t = transform[0:3, 3]
+            q = tf.transformations.quaternion_from_matrix(transform)
+            oxts_tf = Transform()
 
-        oxts_tf.translation.x = t[0]
-        oxts_tf.translation.y = t[1]
-        oxts_tf.translation.z = t[2]
+            oxts_tf.translation.x = t[0]
+            oxts_tf.translation.y = t[1]
+            oxts_tf.translation.z = t[2]
 
-        oxts_tf.rotation.x = q[0]
-        oxts_tf.rotation.y = q[1]
-        oxts_tf.rotation.z = q[2]
-        oxts_tf.rotation.w = q[3]
+            oxts_tf.rotation.x = q[0]
+            oxts_tf.rotation.y = q[1]
+            oxts_tf.rotation.z = q[2]
+            oxts_tf.rotation.w = q[3]
 
-        tf_oxts_transform.transform = oxts_tf
-        tf_oxts_msg.transforms.append(tf_oxts_transform)
+            tf_oxts_transform.transform = oxts_tf
+            tf_oxts_msg.transforms.append(tf_oxts_transform)
 
-        bag.write('/tf', tf_oxts_msg, tf_oxts_msg.transforms[0].header.stamp)
+            bag.write('/tf', tf_oxts_msg, tf_oxts_msg.transforms[0].header.stamp)
 
+    elif kitti_type.find("odom") != -1:
+        timestamps = map(lambda x: initial_time + x.total_seconds(), kitti.timestamps)
+        for timestamp, tf_matrix in zip(timestamps, kitti.T_w_cam0):
+            tf_msg = TFMessage()
+            tf_stamped = TransformStamped()
+            tf_stamped.header.stamp = rospy.Time.from_sec(timestamp)
+            tf_stamped.header.frame_id = 'world'
+            tf_stamped.child_frame_id = 'camera_left'
+            
+            t = tf_matrix[0:3, 3]
+            q = tf.transformations.quaternion_from_matrix(tf_matrix)
+            transform = Transform()
+
+            transform.translation.x = t[0]
+            transform.translation.y = t[1]
+            transform.translation.z = t[2]
+
+            transform.rotation.x = q[0]
+            transform.rotation.y = q[1]
+            transform.rotation.z = q[2]
+            transform.rotation.w = q[3]
+
+            tf_stamped.transform = transform
+            tf_msg.transforms.append(tf_stamped)
+
+            bag.write('/tf', tf_msg, tf_msg.transforms[0].header.stamp)
+          
         
 def save_camera_data(bag, kitti_type, kitti, util, bridge, camera, camera_frame_id, topic, initial_time):
     print("Exporting camera {}".format(camera))
@@ -310,14 +339,13 @@ def main():
 
             # Export
             save_static_transforms(bag, transforms, kitti.timestamps)
-            save_dynamic_tf(bag, kitti)
+            save_dynamic_tf(bag, kitti, args.kitti_type, initial_time=None)
             save_imu_data(bag, kitti, imu_frame_id, imu_topic)
             save_gps_fix_data(bag, kitti, imu_frame_id, gps_fix_topic)
             save_gps_vel_data(bag, kitti, imu_frame_id, gps_vel_topic)
             for camera in cameras:
                 save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2], initial_time=None)
             save_velo_data(bag, kitti, velo_frame_id, velo_topic)
-
 
         finally:
             print("## OVERVIEW ##")
@@ -331,19 +359,23 @@ def main():
             print("Usage for odometry dataset: kitti2bag {odom_color, odom_gray} [dir] -s <sequence>")
             sys.exit(1)
             
-        bag = rosbag.Bag("kitti_data_odometry_{}.bag".format(args.kitti_type[5:]), 'w', compression=compression)
+        bag = rosbag.Bag("kitti_data_odometry_{}_sequence_{}.bag".format(args.kitti_type[5:],args.sequence), 'w', compression=compression)
         
         kitti = pykitti.odometry(args.dir, args.sequence)
         if not os.path.exists(kitti.sequence_path):
             print('Path {} does not exists. Exiting.'.format(kitti.sequence_path))
             sys.exit(1)
 
-        kitti.load_calib()        
-        kitti.load_timestamps()  
-        #kitti.load_poses()     
+        kitti.load_calib()         
+        kitti.load_timestamps() 
+             
         if len(kitti.timestamps) == 0:
             print('Dataset is empty? Exiting.')
             sys.exit(1)
+            
+        if args.sequence in odometry_sequences[:11]:
+            print("Odometry dataset sequence {} has ground truth information (poses).".format(args.sequence))
+            kitti.load_poses()
 
         try:
             util = pykitti.utils.read_calib_file(os.path.join(args.dir,'sequences',args.sequence, 'calib.txt'))
@@ -354,6 +386,7 @@ def main():
             elif args.kitti_type.find("color") != -1:
                 used_cameras = cameras[-2:]
 
+            save_dynamic_tf(bag, kitti, args.kitti_type, initial_time=current_epoch)
             for camera in used_cameras:
                 save_camera_data(bag, args.kitti_type, kitti, util, bridge, camera=camera[0], camera_frame_id=camera[1], topic=camera[2], initial_time=current_epoch)
 


### PR DESCRIPTION
Hey, I added support for odometry datasets and changed few things. This is my first pull request ever, so excuse any silly things I might have done. I tried to keep the original style and functions as much as possible.

So the highlights;
* The original argument handling was tailored for raw datasets only. I imported **argparse** to create a nicer command line interface. I changed the way kitti2bag accepts arguments to be able to select different dataset types.
* The new command line interface is as follows;
```
usage: kitti2bag [-h] [-t DATE] [-r DRIVE]
                    [-s {00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}]
                    {raw_synced,odom_color,odom_gray} [dir]

Convert KITTI dataset to ROS bag file the easy way!

positional arguments:
  {raw_synced,odom_color,odom_gray}
                        KITTI dataset type
  dir                   base directory of the dataset, if no directory passed
                        the deafult is current working directory

optional arguments:
  -h, --help            show this help message and exit
  -t DATE, --date DATE  date of the raw dataset (i.e. 2011_09_26), option is
                        only for RAW datasets.
  -r DRIVE, --drive DRIVE
                        drive number of the raw dataset (i.e. 0001), option is
                        only for RAW datasets.
  -s {00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}, --sequence {00,01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}
                        sequence of the odometry dataset (between 00 - 21),
                        option is only for ODOMETRY datasets.
```

So for example to convert a raw dataset;
```
kitti2bag raw_synced -t 2011_09_26 -r 0002
```
or
```
kitti2bag raw_synced <directory that contains 2011_09_26/> -t 2011_09_26 -r 0002
```

And for a gray scale odometry dataset;
```
kitti2bag odom_gray <directory that contains sequences/> -s 00
```

* Both color and gray odometry datasets are supported. The stereo images and dynamic tf are being exported. 
* The accepted types right now are `raw_synced`, `odom_color` and `odom_gray`.