### PR TITLE
Fix bug

### DIFF
--- a/bin/kitti2bag
+++ b/bin/kitti2bag
@@ -232,9 +232,9 @@ def main():
         print('Path {} does not exists. Exiting.'.format(kitti.data_path))
         sys.exit(1)
 
-    kitti.load_calib()
-    kitti.load_oxts()
-    kitti.load_timestamps()
+    kitti._load_calib()
+    # kitti.load_oxts()
+    kitti._load_timestamps()
     # kitti.load_velo()
 
     if len(kitti.timestamps) == 0:


### PR DESCRIPTION
Hello!

When using kitti2bag, the following error occurred.
**AttributeError: raw instance has no attribute 'load_calib'**

When checking the code, the reference name of pykitti's function was incorrect.
This pull request fix the bug.

Regards