### PR TITLE
Force install a py2 compatible version of pandas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
     python-pip python-matplotlib \
   && rm -rf /var/lib/apt/lists/*
 COPY . /kitti2bag
+RUN pip install pandas==0.23
 RUN pip install -e /kitti2bag
 
 WORKDIR /data


### PR DESCRIPTION
kitti2bag depends on pykitti which depends on pandas
which deprecated py2 support in 0.24 causing breakage
in the docker build. This patch works around this issue
by first installing a py2 compatible version of pandas
before installing kitti2bag.