### PR TITLE
Support for unsynced+unrectified. Velodyne points with unique timestamps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ topics:      /kitti/camera_color_left/camera_info    77 msgs    : sensor_msgs/Ca
 
 That's it. You have file `kitti_2011_09_26_drive_0002_sync.bag` that contains your data.
 
+__NEW:__
+Now `kitti2bag` supports unsynced raw datasets, try it out running:
+```
+$ kitti2bag -t 2011_09_26 -r 0002 -v 0 raw_unsynced .
+``` 
+Here the `-v` (`--velo`) argument is set in order to decide what to do with velodyne pointcloud timestamps. By default (`-v 0`) no unique timestamps will be added to each scan point, so the published pcl will include the fields [x, y, z, i]. 
+
+Set `-v 1` in order to add a timestamp for each point (now [x, y, z, intensity, time]) in the same order as they're found in the dataset file. 
+
+Set `-v 2` in order to add a timestamp for each point taking into account the LiDAR rotational motion. This is an approximation/simulation as there's no info in the dataset to be able to perform this action. However, it can be really useful when testing algorithms that perform any deskewing operation (e.g. Lidar-Inertial SLAM).
+
+_NOTE: both args `-v 1/2` will record the velodyne pointcloud in the same way as the official __ROS velodyne driver__, that is with the fields [x, y, z, intensity, time]._
+
 Other source files can be found at [KITTI raw data](http://www.cvlibs.net/datasets/kitti/raw_data.php) page.
 
 If you got an error saying something like _command not found_ it means that your python installation is in bad shape. You might try running 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Help me make this feature rich and complete. Just fork this repo, implement new 
 Feature request list:
  * make [URDF](http://wiki.ros.org/urdf) of a car so transformations between frames are easily done by ROS itself.
  * deal with tracklets
- * support for unsynced+unrectified version
  * provide documentation via [ROS wiki](wiki.ros.org)
  * provide simple GUI
  * distribute publically available bagfiles (is there a reliable public storage for this purpose?)
@@ -96,7 +95,7 @@ topics:      /kitti/camera_color_left/camera_info    77 msgs    : sensor_msgs/Ca
 
 That's it. You have file `kitti_2011_09_26_drive_0002_sync.bag` that contains your data.
 
-__NEW:__
+__NEW!__
 Now `kitti2bag` supports unsynced raw datasets, try it out running:
 ```
 $ kitti2bag -t 2011_09_26 -r 0002 -v 0 raw_unsynced .

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Here the `-v` (`--velo`) argument is set in order to decide what to do with velo
 
 Set `-v 1` in order to add a timestamp for each point (now [x, y, z, intensity, time]) in the same order as they're found in the dataset file. 
 
-Set `-v 2` in order to add a timestamp for each point taking into account the LiDAR rotational motion. This is an approximation/simulation as there's no info in the dataset to be able to perform this action. However, it can be really useful when testing algorithms that perform any deskewing operation (e.g. Lidar-Inertial SLAM).
+Set `-v 2` in order to add a timestamp for each point taking into account the LiDAR rotational motion (linear interpolation based on computed azimuth angle). This is an approximation as there's no info in the dataset to be able to perform this action. However, it can be really useful when testing algorithms that perform any deskewing operation (e.g. Lidar-Inertial SLAM).
 
 _NOTE: both args `-v 1/2` will record the velodyne pointcloud in the same way as the official __ROS velodyne driver__, that is with the fields [x, y, z, intensity, time]._
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,11 @@ That's it. You have file `kitti_2011_09_26_drive_0002_sync.bag` that contains yo
 __NEW!__
 Now `kitti2bag` supports unsynced raw datasets, try it out running:
 ```
-$ kitti2bag -t 2011_09_26 -r 0002 -v 0 raw_unsynced .
+$ kitti2bag -t 2011_09_26 -r 0002 -v raw_unsynced .
 ``` 
-Here the `-v` (`--velo`) argument is set in order to decide what to do with velodyne pointcloud timestamps. By default (`-v 0`) no unique timestamps will be added to each scan point, so the published pcl will include the fields [x, y, z, i]. 
+Here the `-v` (`--velo`) argument is optional. If `-v` is not present no unique timestamps will be added to each scan point, so the published pcl will include the fields [x,y,z,i]. On the contrary, if `-v` is present a timestamp for each point will be added taking into account the LiDAR rotational motion (linear interpolation based on the computed azimuth angle). This is actually an approximation as there's no info in the dataset to be able substract the real points timestamps. However, it can be really useful when testing algorithms that perform any deskewing operation (e.g. LiDAR-Inertial SLAM approaches).
 
-Set `-v 1` in order to add a timestamp for each point (now [x, y, z, intensity, time]) in the same order as they're found in the dataset file. 
-
-Set `-v 2` in order to add a timestamp for each point taking into account the LiDAR rotational motion (linear interpolation based on computed azimuth angle). This is an approximation as there's no info in the dataset to be able to perform this action. However, it can be really useful when testing algorithms that perform any deskewing operation (e.g. Lidar-Inertial SLAM).
-
-_NOTE: both args `-v 1/2` will record the velodyne pointcloud in the same way as the official __ROS velodyne driver__, that is with the fields [x, y, z, intensity, time]._
+_NOTE: arg `-v` will record the velodyne pointcloud in the same way as the official __ROS velodyne driver__, that is with the fields [x, y, z, intensity, time]._
 
 Other source files can be found at [KITTI raw data](http://www.cvlibs.net/datasets/kitti/raw_data.php) page.
 

--- a/kitti2bag/kitti2bag.py
+++ b/kitti2bag/kitti2bag.py
@@ -193,7 +193,7 @@ def save_velo_data(bag, kitti, velo_frame_id, topic):
         
         dt_step = ( float(datetime.strftime(dtN, "%s.%f")) - float(datetime.strftime(dt0, "%s.%f")) ) / scan.shape[0]
 
-        pc_stamps = (np.arange(float(datetime.strftime(dt0, "%s.%f")) + dt_step, float(datetime.strftime(dtN, "%s.%f")), dt_step)).reshape(-1,1)
+        pc_stamps = (np.arange(float(datetime.strftime(dt0, "%s.%f")), float(datetime.strftime(dtN, "%s.%f")), dt_step)).reshape(-1,1)
         if pc_stamps.shape[0] > scan.shape[0]:
             pc_stamps = pc_stamps[:-1]
 

--- a/kitti2bag/kitti2bag.py
+++ b/kitti2bag/kitti2bag.py
@@ -193,7 +193,7 @@ def save_velo_data(bag, kitti, velo_frame_id, topic):
         
         dt_step = ( float(datetime.strftime(dtN, "%s.%f")) - float(datetime.strftime(dt0, "%s.%f")) ) / scan.shape[0]
 
-        pc_stamps = (np.arange(float(datetime.strftime(dt0, "%s.%f")), float(datetime.strftime(dtN, "%s.%f")), dt_step)).reshape(-1,1)
+        pc_stamps = (np.arange(float(datetime.strftime(dt0, "%s.%f")) + dt_step, float(datetime.strftime(dtN, "%s.%f")), dt_step)).reshape(-1,1)
         if pc_stamps.shape[0] > scan.shape[0]:
             pc_stamps = pc_stamps[:-1]
 
@@ -208,8 +208,8 @@ def save_velo_data(bag, kitti, velo_frame_id, topic):
         fields = [PointField('x', 0, PointField.FLOAT32, 1),
                   PointField('y', 4, PointField.FLOAT32, 1),
                   PointField('z', 8, PointField.FLOAT32, 1),
-                  PointField('i', 12, PointField.FLOAT32, 1),
-                  PointField('time', 14, PointField.FLOAT32, 1)]
+                  PointField('intensity', 12, PointField.FLOAT32, 1),
+                  PointField('time', 16, PointField.FLOAT32, 1)]
         pcl_msg = pcl2.create_cloud(header, fields, scan_stamped)
 
         bag.write(topic + '/pointcloud', pcl_msg, t=pcl_msg.header.stamp)

--- a/kitti2bag/kitti2bag.py
+++ b/kitti2bag/kitti2bag.py
@@ -193,7 +193,7 @@ def save_velo_data(bag, kitti, velo_frame_id, topic):
         if pc_stamps.shape[0] > scan.shape[0]:
             pc_stamps = pc_stamps[:-1]
 
-        scan_stamped = np.append(scan, pc_stamps, axis=1)
+        scan_stamped = np.append(scan, pc_stamps, axis=1) # scan = [x, y, z, i, t]xN
 
         # create header
         header = Header()

--- a/kitti2bag/kitti2bag.py
+++ b/kitti2bag/kitti2bag.py
@@ -284,7 +284,7 @@ def save_gps_vel_data(bag, kitti, gps_frame_id, topic):
 def run_kitti2bag():
     parser = argparse.ArgumentParser(description = "Convert KITTI dataset to ROS bag file the easy way!")
     # Accepted argument values
-    kitti_types = ["raw", "raw_synced", "odom_color", "odom_gray"]
+    kitti_types = ["raw_unsynced", "raw_synced", "odom_color", "odom_gray"]
     odometry_sequences = []
     for s in range(22):
         odometry_sequences.append(str(s).zfill(2))

--- a/kitti2bag/kitti2bag.py
+++ b/kitti2bag/kitti2bag.py
@@ -467,3 +467,6 @@ def run_kitti2bag():
             print("## OVERVIEW ##")
             print(bag)
             bag.close()
+
+if __name__ == '__main__':
+    run_kitti2bag()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pykitti==0.3.1
+pandas==1.5.3
+numpy==1.24.4
+progressbar==2.5


### PR DESCRIPTION
Hello there,

I found my self with the need of using the KITTI dataset for testing a LiDAR based SLAM approach, so I decided to add support for unsynced+unrectified datasets. 

I also took the liberty of adding a new argument related to velodyne points timestamps (-v, --velo). Due to the deskewing procedure done by most LiDAR based SLAMs, it's mandatory to have a timestamp for each point of the scan. Because this information is not given by the KITTI dataset, when --velo argument is given, each point's stamp is "approximated"  based on the start and end sweep time. This way, the velodyne pointcloud will be published with the same fields as in the official ROS velodyne driver [x, y, z, intensity, time], where time is relative to the msg header stamp.

Finally, I adapted the use of progressbar library to python3, as it was the only module that failed when executing the script with python 3.8.10.